### PR TITLE
Removed all autofills from Firebase data

### DIFF
--- a/src/app/leader-auditionee/leader-auditionee.component.html
+++ b/src/app/leader-auditionee/leader-auditionee.component.html
@@ -1,19 +1,10 @@
 <div class="leaderAuditionee">
 	<mat-form-field>
-		<mat-select placeholder="Student Leader" [(ngModel)]="studentLeader" required>
-			<mat-option *ngFor="let obj of this.slList | async" [value]="obj">
-				{{obj}}
-			</mat-option>
-		</mat-select>
+			<input matInput type="text" placeholder="Student Leader" [(ngModel)]="studentLeader" required>
 	</mat-form-field>
 
 	<mat-form-field>
-		<input matInput type="text" placeholder="Auditionee" [(ngModel)]="auditionee" [formControl]="myControl" [matAutocomplete]="auto" required>
-		<mat-autocomplete #auto="matAutocomplete">
-			<mat-option *ngFor="let auditionee of this.filteredOptions | async" [value]="auditionee">
-				{{auditionee}}
-			</mat-option>
-		</mat-autocomplete>
+		<input matInput type="text" placeholder="Auditionee" [(ngModel)]="auditionee" required>
 	</mat-form-field>
 	<div>
 		<ng-template #target></ng-template>

--- a/src/app/leader-auditionee/leader-auditionee.component.ts
+++ b/src/app/leader-auditionee/leader-auditionee.component.ts
@@ -20,12 +20,10 @@ import 'rxjs/add/operator/filter';
 export class LeaderAuditioneeComponent implements AfterViewInit, OnInit {
 	@ViewChild('target', { read: ViewContainerRef }) target: ViewContainerRef;
 	public judgementList: Array<ComponentRef<JudgementComponent>> = [];
-	public studentLeader: string = '';
-	public auditionee: string = '';
+	public studentLeader: string;
+	public auditionee: string;
 	public auditioneeList: Array<any> = [];
 	public slList: Observable<string[]>;
-	public myControl: FormControl = new FormControl();
-	public filteredOptions: Observable<string[]>;
 
 	constructor(private cfr: ComponentFactoryResolver,
 							private db: AngularFireDatabase,
@@ -34,17 +32,7 @@ export class LeaderAuditioneeComponent implements AfterViewInit, OnInit {
 							private auditService: AuditioneesService) { }
 
 	ngOnInit() {
-		// fill student leaders list
-		this.slList = this.service.getStudentLeaders().valueChanges();
 
-		// fill auditionees list
-		this.auditService.getAuditionees().forEach(data => {
-			for (var item of data) {
-				this.auditioneeList.push(item);
-			}
-			this.filteredOptions = this.myControl.valueChanges.startWith(null).map(val =>
-				val ? this.filter(val) : this.auditioneeList.slice());
-		});
 	}
 
 	filter(val: string): any[] {
@@ -56,14 +44,14 @@ export class LeaderAuditioneeComponent implements AfterViewInit, OnInit {
 	}
 
 	public putInMyHtml() {
-		let compFactory = this.cfr.resolveComponentFactory(JudgementComponent);
+		const compFactory = this.cfr.resolveComponentFactory(JudgementComponent);
 		this.judgementList.push(this.target.createComponent(compFactory));
 		this.cdr.detectChanges();
 	}
 
 	public submitComment() {
-		for (var item of this.judgementList) {
-			var instance = item.instance;
+		for (const item of this.judgementList) {
+			const instance = item.instance;
 			const newJudgement = {
 				studentLeader: this.studentLeader,
 				criteria: instance.getCriteria(),


### PR DESCRIPTION
This can be implemented later, but I want a workable baseline version
for 2.0 deployment that can be utilized at band camp instead of trying to get
this to work with how we're reshaping the site right now.   Selection from lists/autofilling (besides the criteria list) has been set to text inputs.